### PR TITLE
Prefer GitHub's native color variables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,9 +1,9 @@
 /* Copyright (C) 2021 Katsute <https://github.com/Katsute> */
 
 :root {
-    --rcie-pull-merged: #8957e5;
-    --rcie-issue-closed: #F85149;
-    --rcie-white: #F0F6Fc;
+    --rcie-pull-merged: var(--color-done-emphasis, #8957e5);
+    --rcie-issue-closed: var(--color-danger-fg, #F85149);
+    --rcie-white: var(--color-fg-on-emphasis, #F0F6Fc);
 }
 
 /* issue icon */


### PR DESCRIPTION
The predefined colors are from GitHub's "Default dark" theme and hence does not match with other themes. This PR let `--rcie-*` variables use GitHub's native color variables first.

Also, since this is (now) a CSS-only extension, would be convenient to make the stylesheet also a [UserCSS](https://github.com/openstyles/stylus/wiki/Usercss#what-is-usercss) so it can be used with a user style manager.